### PR TITLE
Have docs' summary be spectrum friendly, use sidenav spectrum element

### DIFF
--- a/src/summary_html.htl
+++ b/src/summary_html.htl
@@ -11,6 +11,12 @@
 * governing permissions and limitations under the License.
 */
 -->
-<div data-sly-test="${payload.content.nav}" data-sly-list="${payload.content.nav}">
+<nav data-sly-test="${payload.content.nav}">
+  <ul class="spectrum-SideNav spectrum-SideNav--multilevel" data-sly-list="${payload.content.nav}">
     ${item.outerHTML}
-</div>
+  </ul>
+</nav>
+<script type="text/javascript">
+var pathname = window.location.pathname;
+document.querySelector("a[href='" + pathname + "']").parentNode.classList.add('is-selected');
+</script>


### PR DESCRIPTION
FYI @kptdobe in the summary.pre.js I did not have access to the request URL; the payload request and action request properties all reference the url to the markdown repo - not the request URL. So I ended up solving the problem I had (applying a `is-selected` css class to the currently-viewed document) via clientside JavaScript in the htl 😇not sure if this should be something that the pre.js has access to or not.

This closes #60 and #108 .