### PR TITLE
Make homepage a faithful representation of mocks

### DIFF
--- a/htdocs/footer.css
+++ b/htdocs/footer.css
@@ -1,5 +1,7 @@
 #footer {
     padding: 25px;
+    margin: 0 -8px;
+    background-color: black;
 }
 
 #footer > svg#dark_logo {

--- a/htdocs/homepage.css
+++ b/htdocs/homepage.css
@@ -57,9 +57,9 @@ body { margin:0; }
     margin: 0 15px;
 }
 
-.index4 {
+#techblog {
     background-color:#EFEFEF;
-
+    width: 100%
 }
 
 .search-control {

--- a/htdocs/homepage.css
+++ b/htdocs/homepage.css
@@ -7,7 +7,7 @@ body { margin:0; }
 }
 
 .section {
-    padding: 70px 20px 20px 20px;
+    padding: 50px 20px 20px 20px;
 }
 
 .li-no-margin-bottom {
@@ -24,6 +24,10 @@ body { margin:0; }
 .index0 svg {
     left: 7px;
 }
+.index0 .search-control {
+    padding-top:20px;
+}
+
 
 .index1 p:first-child {
     display:flex;
@@ -56,17 +60,26 @@ body { margin:0; }
 .index3 p:first-child code {
     margin: 0 15px;
 }
+.index5 .spectrum-DecoratedTextfield {
+    display: inherit;
+}
+.index5 .newsletter-control input {
+    width: 100%;
+}
+.index5 #newsletter-submit {
+    border:none;
+    background-color:#EFEFEF;
+    top:24px;
+    right:0px;
+    bottom:0px;
+    width:inherit;
+    height:inherit;
+    color: #2b2b2b;
+}
 
 #techblog {
     background-color:#EFEFEF;
     width: 100%
-}
-
-.search-control {
-    padding-top:20px;
-}
-.search-bar {
-    width:180%;
 }
 
 .removeStyle {

--- a/htdocs/homepage.css
+++ b/htdocs/homepage.css
@@ -1,3 +1,4 @@
+body { margin:0; }
 .container {
     display: flex;
     height: 100%;
@@ -40,6 +41,11 @@
     padding-top:10px;
 }
 
+.index2 .guide-indent {
+    border-left: solid #555555;
+    padding-left: 20px;
+}
+
 .index3 p:first-child {
     display:flex;
     align-items:center;
@@ -66,6 +72,7 @@
 .removeStyle {
     display: inline-flex;
     padding: 0;
+    margin: 0;
     list-style-type: none;
 }
 

--- a/htdocs/topnav.css
+++ b/htdocs/topnav.css
@@ -6,7 +6,6 @@
 }
 
 .main-nav {
-        list-style-type: none;
         padding-left: 20px;
         list-style-type: none;
         display: none;
@@ -16,8 +15,6 @@
 .logo {
         text-decoration: none;
         color: rgba(2, 2, 2, 0.7);
-}
-.logo {
         display: inline-block;
         font-size: 22px;
         margin: 0 auto;

--- a/htdocs/topnav.css
+++ b/htdocs/topnav.css
@@ -8,12 +8,21 @@
 .main-nav {
         list-style-type: none;
         padding-left: 20px;
+        list-style-type: none;
+        display: none;
 }
 
 .nav-links,
 .logo {
         text-decoration: none;
         color: rgba(2, 2, 2, 0.7);
+}
+.logo {
+        display: inline-block;
+        font-size: 22px;
+        margin: 0 auto;
+        position:relative;
+        top:10px;
 }
 
 .logo-text {
@@ -22,7 +31,10 @@
         overflow: hidden;
         font-size: 18px;
         font-weight: 700;
-        color: #2d2d2d
+        color: #2d2d2d;
+        position:relative;
+        top: -4px;
+        left: 8px;
 }
 
 .main-nav li {
@@ -31,31 +43,16 @@
 }
 
 .navbar-logos {
-        display:flex
-}
-
-.logo {
-        display: inline-block;
-        font-size: 22px;
-        margin-right:auto;
+        display:flex;
 }
 
 .navbar-toggle {
-        margin-right:auto;
-}
-
-.navbar-toggle {
-        /*position: absolute;
-        top: 10px;*/
-        right: 20px;
+        position: absolute;
+        left: 15px;
+        top: 8px;
         cursor: pointer;
-        color: rgba(5, 5, 5, 0.8);
+        color: rgba(5, 5, 5, 0.5);
         font-size: 24px;
-}
-
-.main-nav {
-        list-style-type: none;
-        display: none;
 }
 
 .active {

--- a/index.md
+++ b/index.md
@@ -46,5 +46,3 @@ The Adobe Analytics APIs are a collection of APIs that power Adobe Analytics pro
 
 ## Recent Blog Articles
 
-Latest from the [Adobe Tech Blog](https://medium.com/adobetech).
-

--- a/src/default_html.htl
+++ b/src/default_html.htl
@@ -1,64 +1,78 @@
-<div class="container spectrum-grid-row spectrum-Body3">
-  <div class="section index0 odd has-paragraph has-heading has-inlineCode nb-paragraph-1 nb-heading-1 nb-inlineCode-1 is-paragraph-heading-inlineCode is-paragraph-heading is-paragraph spectrum-grid-col-sm-12 spectrum-grid-col-md-6 spectrum--dark"><p class="spectrum-Body3"><code class="spectrum-Code3">Find what you're looking for</code></p>
-  <h2 class="spectrum-Heading2">Do More with Adobe</h2>
-  <p class="spectrum-Body3">Customize and extend Adobe’s products to create better customer experiences with our APIs, help guides and community support.</p>
-  <div class="search-control">
-    <div class="spectrum-DecoratedTextfield is-decorated">
-      <label for="search-input" class="spectrum-FieldLabel">Search our products and documentation</label>
-      <svg class="spectrum-Icon spectrum-UIIcon-Magnifier spectrum-Icon--sizeS spectrum-DecoratedTextfield-icon" focusable="false" aria-hidden="true" style="color: rgb(75, 75, 75);transform: rotate(90deg);margin-left:10px;">
-        <use xlink:href="#spectrum-css-icon-Magnifier"></use>
-      </svg>
-      <input id="search-input" class="spectrum-Textfield spectrum-DecoratedTextfield-field" aria-invalid="false" type="text" style="background-color: rgb(255, 255, 255);border-color: rgb(225, 225, 225);color: rgb(75, 75, 75); border-radius: 30px;">
+<div class="container spectrum-grid-row">
+  <div class="section index0 odd has-paragraph has-heading has-inlineCode nb-paragraph-1 nb-heading-1 nb-inlineCode-1 is-paragraph-heading-inlineCode is-paragraph-heading is-paragraph spectrum-grid-col-sm-12 spectrum-grid-col-md-6 spectrum--dark">
+    <p class="spectrum-Body3"><code class="spectrum-Code3">Find what you're looking for</code></p>
+    <h2 class="spectrum-Heading2">Do More with Adobe</h2>
+    <p class="spectrum-Body3">Customize and extend Adobe’s products to create better customer experiences with our APIs, help guides and community support.</p>
+    <div class="search-control">
+      <div class="spectrum-DecoratedTextfield is-decorated">
+        <label for="search-input" class="spectrum-FieldLabel">Search our products and documentation</label>
+        <svg class="spectrum-Icon spectrum-UIIcon-Magnifier spectrum-Icon--sizeS spectrum-DecoratedTextfield-icon" focusable="false" aria-hidden="true" style="color: rgb(75, 75, 75);transform: rotate(90deg);margin-left:10px;">
+          <use xlink:href="#spectrum-css-icon-Magnifier"></use>
+        </svg>
+        <input id="search-input" class="spectrum-Textfield spectrum-DecoratedTextfield-field" aria-invalid="false" type="text" style="background-color: rgb(255, 255, 255);border-color: rgb(225, 225, 225);color: rgb(75, 75, 75); border-radius: 30px;">
+      </div>
     </div>
   </div>
-</div>
-<div class="section index1 even has-link has-paragraph has-heading has-image has-inlineCode nb-link-2 nb-paragraph-1 nb-heading-1 nb-image-1 nb-inlineCode-1 is-link-paragraph-heading is-link-paragraph is-link spectrum-grid-col-sm-12 spectrum-grid-col-md-6">
-  <p class="spectrum-Body3">
-    <img src="https://www.adobe.io/content/dam/udp/language-masters/en/xd_logo_43733775.svg" alt="XD Logo">
-    <code class="spectrum-Code3">The future of extending creative cloud apps</code>
-  </p>
-  <h1 class="spectrum-Heading1">Start Building with Adobe XD today</h1>
-  <p class="spectrum-Body3">Create XD plugins to push the boundaries of experience design by adding new features to <a href="https://adobexdplatform.com/" class="spectrum-Link">Adobe XD</a>, automating workflows, connecting XD to external services, and more—all on a quick, modern JavaScript engine with native UI components.</p>
-  <p class="spectrum-Body3">Let’s supercharge the future of design together with XD plugins.</p>
-  <p class="spectrum-Body3"><a href="/xd/docs" class="spectrum-Link spectrum-Button spectrum-Button--primary">See What’s Possible</a></p>
-</div>
-<div class="section index2 odd has-list has-paragraph has-heading nb-list-2 nb-paragraph-2 nb-heading-3 is-heading-list-paragraph is-heading-list is-heading spectrum-grid-col-sm-12 spectrum-grid-col-md-6 spectrum--dark">
-  <h2 class="spectrum-Heading2">Authentication Guides</h2>
-  <div class="guide-indent">
-    <h3 class="spectrum-Heading3">OAuth 2.0</h3>
-    <p class="spectrum-Body3">Adobe Cloud Platform APIs use the OAuth 2.0 protocol for authentication and authorization.</p>
-    <ul class="removeStyle">
-      <li class="spectrum-Body3 li-no-margin-bottom"><a href="https://adobeioruntime.net/api/v1/web/io-solutions/adobe-oauth-playground/oauth.html" class="spectrum-Link spectrum-Button spectrum-Button--cta button-read">Read our Guide</a></li>
-      <li class="spectrum-Body3 li-no-margin-bottom"><a href="" class="spectrum-Link spectrum-Button spectrum-Button--primary">Generate Tokens</a></li>
-    </ul>
+  <div class="section index1 even has-link has-paragraph has-heading has-image has-inlineCode nb-link-2 nb-paragraph-1 nb-heading-1 nb-image-1 nb-inlineCode-1 is-link-paragraph-heading is-link-paragraph is-link spectrum-grid-col-sm-12 spectrum-grid-col-md-6">
+    <p class="spectrum-Body3">
+      <img src="https://www.adobe.io/content/dam/udp/language-masters/en/xd_logo_43733775.svg" alt="XD Logo">
+      <code class="spectrum-Code3">The future of extending creative cloud apps</code>
+    </p>
+    <h1 class="spectrum-Heading1">Start Building with Adobe XD today</h1>
+    <p class="spectrum-Body3">Create XD plugins to push the boundaries of experience design by adding new features to <a href="https://adobexdplatform.com/" class="spectrum-Link">Adobe XD</a>, automating workflows, connecting XD to external services, and more—all on a quick, modern JavaScript engine with native UI components.</p>
+    <p class="spectrum-Body3">Let’s supercharge the future of design together with XD plugins.</p>
+    <p class="spectrum-Body3"><a href="/xd/docs" class="spectrum-Link spectrum-Button spectrum-Button--primary">See What’s Possible</a></p>
   </div>
-  <div class="guide-indent">
-    <h3 class="spectrum-Heading3">JWT Quickstart</h3>
-    <p class="spectrum-Body3">API services tied to entitled Adobe products require a JSON Web Token (JWT) to retrieve access tokens for usage against authenticated endpoints</p>
-    <ul class="removeStyle">
-      <li class="spectrum-Body3 li-no-margin-bottom"><a href="https://www.adobe.io/authentication/auth-methods.html#!adobeio/adobeio-documentation/master/auth/JWTAuthenticationQuickStart.md" class="spectrum-Link spectrum-Button spectrum-Button--cta button-read">Read our Guide</a></li>
-    </ul>
+  <div class="section index2 odd has-list has-paragraph has-heading nb-list-2 nb-paragraph-2 nb-heading-3 is-heading-list-paragraph is-heading-list is-heading spectrum-grid-col-sm-12 spectrum-grid-col-md-6 spectrum--dark">
+    <h2 class="spectrum-Heading2">Authentication Guides</h2>
+    <div class="guide-indent">
+      <h3 class="spectrum-Heading3">OAuth 2.0</h3>
+      <p class="spectrum-Body3">Adobe Cloud Platform APIs use the OAuth 2.0 protocol for authentication and authorization.</p>
+      <ul class="removeStyle">
+        <li class="spectrum-Body3 li-no-margin-bottom"><a href="https://adobeioruntime.net/api/v1/web/io-solutions/adobe-oauth-playground/oauth.html" class="spectrum-Link spectrum-Button spectrum-Button--cta button-read">Read our Guide</a></li>
+        <li class="spectrum-Body3 li-no-margin-bottom"><a href="" class="spectrum-Link spectrum-Button spectrum-Button--primary">Generate Tokens</a></li>
+      </ul>
+    </div>
+    <div class="guide-indent">
+      <h3 class="spectrum-Heading3">JWT Quickstart</h3>
+      <p class="spectrum-Body3">API services tied to entitled Adobe products require a JSON Web Token (JWT) to retrieve access tokens for usage against authenticated endpoints</p>
+      <ul class="removeStyle">
+        <li class="spectrum-Body3 li-no-margin-bottom"><a href="https://www.adobe.io/authentication/auth-methods.html#!adobeio/adobeio-documentation/master/auth/JWTAuthenticationQuickStart.md" class="spectrum-Link spectrum-Button spectrum-Button--cta button-read">Read our Guide</a></li>
+      </ul>
+    </div>
   </div>
-</div>
-<div class="section index3 even has-link has-paragraph has-heading has-image has-inlineCode nb-link-1 nb-paragraph-1 nb-heading-1 nb-image-1 nb-inlineCode-1 is-link-paragraph-heading is-link-paragraph is-link spectrum-grid-col-sm-12 spectrum-grid-col-md-6">
-  <p class="spectrum-Body3">
-    <img src="https://www.adobe.com/content/dam/www/icons/analytics-cloud.svg" alt="Adobe Analytics Logo">
-    <code class="spectrum-Code3">Product Spotlight</code>
-  </p>
-  <h2 class="spectrum-Heading2">Adobe Analytics APIs</h2>
-  <p class="spectrum-Body3">The Adobe Analytics APIs are a collection of APIs that power Adobe Analytics products like Analysis Workspace. The APIs allow for the creation of data rich user interfaces that you can use to manipulate and integrate data. You can also create reports to explore, get insights, or answer important questions about your data.</p>
-  <p class="spectrum-Body3"><a href="" class="spectrum-Link spectrum-Button spectrum-Button--cta">Read the Docs</a></p>
-</div>
-<div id="techblog" class="section index4 odd has-heading nb-heading-1 is-heading-only spectrum-grid-col-sm-12 spectrum-grid-col-md-6" data-sly-test="${content.mediumArticles}">
-  <h2 class="spectrum-Heading2">Recent Blog Articles</h2>
-  <hr class="spectrum-Rule spectrum-Rule--medium">
-  <div id="techblog-article-container" data-sly-list="${content.mediumArticles}">
-    <div>
-      <code class="spectrum-Code5">${item.pubDate} · ${item.minuteLength} min read · <strong>${item.creator}</strong></code>
-      <h4 class="spectrum-Heading4">${item.title}</h4>
-      <p class="spectrum-Body4">${item.caption}</p>
-      <a href="${item.link}" class="spectrum-Button spectrum-Button--primary" style="margin: 20px 0;">Read On</a>
-      <hr class="spectrum-Rule spectrum-Rule--medium">
+  <div class="section index3 even has-link has-paragraph has-heading has-image has-inlineCode nb-link-1 nb-paragraph-1 nb-heading-1 nb-image-1 nb-inlineCode-1 is-link-paragraph-heading is-link-paragraph is-link spectrum-grid-col-sm-12 spectrum-grid-col-md-6">
+    <p class="spectrum-Body3">
+      <img src="https://www.adobe.com/content/dam/www/icons/analytics-cloud.svg" alt="Adobe Analytics Logo">
+      <code class="spectrum-Code3">Product Spotlight</code>
+    </p>
+    <h2 class="spectrum-Heading2">Adobe Analytics APIs</h2>
+    <p class="spectrum-Body3">The Adobe Analytics APIs are a collection of APIs that power Adobe Analytics products like Analysis Workspace. The APIs allow for the creation of data rich user interfaces that you can use to manipulate and integrate data. You can also create reports to explore, get insights, or answer important questions about your data.</p>
+    <p class="spectrum-Body3"><a href="" class="spectrum-Link spectrum-Button spectrum-Button--cta">Read the Docs</a></p>
+  </div>
+  <div id="techblog" class="section index4 odd has-heading nb-heading-1 is-heading-only spectrum-grid-col-sm-12 spectrum-grid-col-md-6" data-sly-test="${content.mediumArticles}">
+    <h2 class="spectrum-Heading2">Recent Blog Articles</h2>
+    <hr class="spectrum-Rule spectrum-Rule--medium">
+    <div id="techblog-article-container" data-sly-list="${content.mediumArticles}">
+      <div>
+        <code class="spectrum-Code5">${item.pubDate} · ${item.minuteLength} min read · <strong>${item.creator}</strong></code>
+        <h4 class="spectrum-Heading4">${item.title}</h4>
+        <p class="spectrum-Body4">${item.caption}</p>
+        <a href="${item.link}" class="spectrum-Button spectrum-Button--primary" style="margin: 20px 0;">Read On</a>
+        <hr class="spectrum-Rule spectrum-Rule--medium">
+      </div>
+    </div>
+  </div>
+  <div class="section index5 even spectrum-grid-col-sm-12 spectrum-grid-col-md-6 spectrum--darkest">
+    <h2 class="spectrum-Heading2--quiet"><strong>Sign up</strong> for our developer newsletter</h2>
+    <div class="newsletter-control">
+      <div class="spectrum-DecoratedTextfield">
+        <label for="email-input" class="spectrum-FieldLabel">Enter your email address</label>
+        <button id="newsletter-submit" class="spectrum-Button spectrum-Button--primary spectrum-DecoratedTextfield-icon">
+          <span class="spectrum-Button-label">Subscribe →</span>
+        </button>
+        <input id="email-input" class="spectrum-Textfield" aria-invalid="false" type="text" style="background-color: rgb(255, 255, 255);border-color: rgb(225, 225, 225);color: rgb(75, 75, 75); border-radius: 30px;">
+      </div>
     </div>
   </div>
 </div>

--- a/src/default_html.htl
+++ b/src/default_html.htl
@@ -1,3 +1,64 @@
-<div class="container spectrum-grid-row spectrum-Body3" data-sly-list="${content.sectionsDocuments}">
-    ${item.outerHTML}
+<div class="container spectrum-grid-row spectrum-Body3">
+  <div class="section index0 odd has-paragraph has-heading has-inlineCode nb-paragraph-1 nb-heading-1 nb-inlineCode-1 is-paragraph-heading-inlineCode is-paragraph-heading is-paragraph spectrum-grid-col-sm-12 spectrum-grid-col-md-6 spectrum--dark"><p class="spectrum-Body3"><code class="spectrum-Code3">Find what you're looking for</code></p>
+  <h2 class="spectrum-Heading2">Do More with Adobe</h2>
+  <p class="spectrum-Body3">Customize and extend Adobe’s products to create better customer experiences with our APIs, help guides and community support.</p>
+  <div class="search-control">
+    <div class="spectrum-DecoratedTextfield is-decorated">
+      <label for="search-input" class="spectrum-FieldLabel">Search our products and documentation</label>
+      <svg class="spectrum-Icon spectrum-UIIcon-Magnifier spectrum-Icon--sizeS spectrum-DecoratedTextfield-icon" focusable="false" aria-hidden="true" style="color: rgb(75, 75, 75);transform: rotate(90deg);margin-left:10px;">
+        <use xlink:href="#spectrum-css-icon-Magnifier"></use>
+      </svg>
+      <input id="search-input" class="spectrum-Textfield spectrum-DecoratedTextfield-field" aria-invalid="false" type="text" style="background-color: rgb(255, 255, 255);border-color: rgb(225, 225, 225);color: rgb(75, 75, 75); border-radius: 30px;">
+    </div>
+  </div>
+</div>
+<div class="section index1 even has-link has-paragraph has-heading has-image has-inlineCode nb-link-2 nb-paragraph-1 nb-heading-1 nb-image-1 nb-inlineCode-1 is-link-paragraph-heading is-link-paragraph is-link spectrum-grid-col-sm-12 spectrum-grid-col-md-6">
+  <p class="spectrum-Body3">
+    <img src="https://www.adobe.io/content/dam/udp/language-masters/en/xd_logo_43733775.svg" alt="XD Logo">
+    <code class="spectrum-Code3">The future of extending creative cloud apps</code>
+  </p>
+  <h1 class="spectrum-Heading1">Start Building with Adobe XD today</h1>
+  <p class="spectrum-Body3">Create XD plugins to push the boundaries of experience design by adding new features to <a href="https://adobexdplatform.com/" class="spectrum-Link">Adobe XD</a>, automating workflows, connecting XD to external services, and more—all on a quick, modern JavaScript engine with native UI components.</p>
+  <p class="spectrum-Body3">Let’s supercharge the future of design together with XD plugins.</p>
+  <p class="spectrum-Body3"><a href="/xd/docs" class="spectrum-Link spectrum-Button spectrum-Button--primary">See What’s Possible</a></p>
+</div>
+<div class="section index2 odd has-list has-paragraph has-heading nb-list-2 nb-paragraph-2 nb-heading-3 is-heading-list-paragraph is-heading-list is-heading spectrum-grid-col-sm-12 spectrum-grid-col-md-6 spectrum--dark">
+  <h2 class="spectrum-Heading2">Authentication Guides</h2>
+  <div class="guide-indent">
+    <h3 class="spectrum-Heading3">OAuth 2.0</h3>
+    <p class="spectrum-Body3">Adobe Cloud Platform APIs use the OAuth 2.0 protocol for authentication and authorization.</p>
+    <ul class="removeStyle">
+      <li class="spectrum-Body3 li-no-margin-bottom"><a href="https://adobeioruntime.net/api/v1/web/io-solutions/adobe-oauth-playground/oauth.html" class="spectrum-Link spectrum-Button spectrum-Button--cta button-read">Read our Guide</a></li>
+      <li class="spectrum-Body3 li-no-margin-bottom"><a href="" class="spectrum-Link spectrum-Button spectrum-Button--primary">Generate Tokens</a></li>
+    </ul>
+  </div>
+  <div class="guide-indent">
+    <h3 class="spectrum-Heading3">JWT Quickstart</h3>
+    <p class="spectrum-Body3">API services tied to entitled Adobe products require a JSON Web Token (JWT) to retrieve access tokens for usage against authenticated endpoints</p>
+    <ul class="removeStyle">
+      <li class="spectrum-Body3 li-no-margin-bottom"><a href="https://www.adobe.io/authentication/auth-methods.html#!adobeio/adobeio-documentation/master/auth/JWTAuthenticationQuickStart.md" class="spectrum-Link spectrum-Button spectrum-Button--cta button-read">Read our Guide</a></li>
+    </ul>
+  </div>
+</div>
+<div class="section index3 even has-link has-paragraph has-heading has-image has-inlineCode nb-link-1 nb-paragraph-1 nb-heading-1 nb-image-1 nb-inlineCode-1 is-link-paragraph-heading is-link-paragraph is-link spectrum-grid-col-sm-12 spectrum-grid-col-md-6">
+  <p class="spectrum-Body3">
+    <img src="https://www.adobe.com/content/dam/www/icons/analytics-cloud.svg" alt="Adobe Analytics Logo">
+    <code class="spectrum-Code3">Product Spotlight</code>
+  </p>
+  <h2 class="spectrum-Heading2">Adobe Analytics APIs</h2>
+  <p class="spectrum-Body3">The Adobe Analytics APIs are a collection of APIs that power Adobe Analytics products like Analysis Workspace. The APIs allow for the creation of data rich user interfaces that you can use to manipulate and integrate data. You can also create reports to explore, get insights, or answer important questions about your data.</p>
+  <p class="spectrum-Body3"><a href="" class="spectrum-Link spectrum-Button spectrum-Button--cta">Read the Docs</a></p>
+</div>
+<div id="techblog" class="section index4 odd has-heading nb-heading-1 is-heading-only spectrum-grid-col-sm-12 spectrum-grid-col-md-6" data-sly-test="${content.mediumArticles}">
+  <h2 class="spectrum-Heading2">Recent Blog Articles</h2>
+  <hr class="spectrum-Rule spectrum-Rule--medium">
+  <div id="techblog-article-container" data-sly-list="${content.mediumArticles}">
+    <div>
+      <code class="spectrum-Code5">${item.pubDate} · ${item.minuteLength} min read · <strong>${item.creator}</strong></code>
+      <h4 class="spectrum-Heading4">${item.title}</h4>
+      <p class="spectrum-Body4">${item.caption}</p>
+      <a href="${item.link}" class="spectrum-Button spectrum-Button--primary" style="margin: 20px 0;">Read On</a>
+      <hr class="spectrum-Rule spectrum-Rule--medium">
+    </div>
+  </div>
 </div>

--- a/src/default_html.pre.js
+++ b/src/default_html.pre.js
@@ -121,10 +121,11 @@ async function pre(payload, action) {
         const secondParagraphContent = (ps[2] ? ps[2].split('</p>')[0] : '');
         let caption = `${firstParagraphContent} ${secondParagraphContent}`;
         if (caption.length > 340) {
-          // TODO: this may cut content that is mid-html-tag. the
-          // `content:encoded` field contains html, too.
           caption = caption.substring(0, 340);
           caption = caption.replace(/\w+$/, '...');
+          const temp = document.createElement('p');
+          temp.innerHTML = caption;
+          caption = temp.innerHTML;
         }
         const div = document.createElement('div');
         div.innerHTML = `<code class="spectrum-Code5">${pubMoment.format('MMM Do')} ${(moment().year() !== pubMoment.year() ? moment.year() : '')} · <strong>${item.creator}</strong></code>
@@ -132,7 +133,7 @@ async function pre(payload, action) {
         <p class="spectrum-Body4">${caption}</p>
         <a href="${item.link}" class="spectrum-Button spectrum-Button--primary" style="margin: 20px 0;">Read On</a>
         <hr class="spectrum-Rule spectrum-Rule--medium">`;
-        DOMUtil.spectrumify(div.querySelector('p.spectrum-Body4'));
+        DOMUtil.spectrumify(div.querySelector('p.spectrum-Body4')); // spectrumify rando content from blog (in case there are links)
         node.appendChild(div);
       });
     }

--- a/src/default_html.pre.js
+++ b/src/default_html.pre.js
@@ -62,7 +62,7 @@ async function pre(payload, action) {
     const types = element.types.slice();
     types.push(`index${index}`);
 
-    DOMUtil.spectrumify(body);
+    DOMUtil.spectrumify(node);
 
     if (node.className.includes('index0')) {
       node.classList.add('spectrum--dark');
@@ -73,10 +73,10 @@ async function pre(payload, action) {
       searchDiv.classList.add('search-control');
       searchDiv.innerHTML = `<div class="spectrum-DecoratedTextfield is-decorated">
   <label for="search-input" class="spectrum-FieldLabel">Search our products and documentation</label>
-  <svg class="spectrum-Icon spectrum-UIIcon-Magnifier spectrum-Icon--sizeS spectrum-DecoratedTextfield-icon" focusable="false" aria-hidden="true">
+  <svg class="spectrum-Icon spectrum-UIIcon-Magnifier spectrum-Icon--sizeS spectrum-DecoratedTextfield-icon" focusable="false" aria-hidden="true" style="color: rgb(75, 75, 75);transform: rotate(90deg);margin-left:10px;">
     <use xlink:href="#spectrum-css-icon-Magnifier" />
   </svg>
-  <input id="search-input" class="spectrum-Textfield spectrum-DecoratedTextfield-field" aria-invalid="false" type="text">
+  <input id="search-input" class="spectrum-Textfield spectrum-DecoratedTextfield-field" aria-invalid="false" type="text" style="background-color: rgb(255, 255, 255);border-color: rgb(225, 225, 225);color: rgb(75, 75, 75); border-radius: 30px;">
 </div>`;
       node.appendChild(searchDiv);
 
@@ -109,6 +109,10 @@ async function pre(payload, action) {
       DOMUtil.addClass(node, 'p:last-of-type a', 'spectrum-Button spectrum-Button--cta');
     }
     if (node.className.includes('index4')) {
+      const hr = document.createElement('hr');
+      hr.classList.add('spectrum-Rule', 'spectrum-Rule--medium');
+      node.appendChild(hr);
+      // this is the medium blog feed
       feed.items.slice(0, 3).forEach((item) => {
         const pubMoment = moment(item.pubDate);
         const ps = item['content:encoded'].split('<p>');
@@ -122,14 +126,13 @@ async function pre(payload, action) {
           caption = caption.substring(0, 340);
           caption = caption.replace(/\w+$/, '...');
         }
-        const div = transformer.getDocument().createElement('div');
-        div.innerHTML = `<p class="spectrum-Body3"><strong>${item.creator}</strong></p>
-<code class="spectrum-Code5">${pubMoment.format('MMM Do')} ${(moment().year() !== pubMoment.year() ? moment.year() : '')}</code>
-<h4 class="spectrum-Heading4">${item.title}</h4>
-<p class="spectrum-Body3">${caption}</p>
-<a href="${item.link}" class="spectrum-Button spectrum-Button--primary" style="margin: 20px 0;">Read On</a>
-<hr class="spectrum-Rule spectrum-Rule--medium">`;
-        div.classList.add('spectrum-Article');
+        const div = document.createElement('div');
+        div.innerHTML = `<code class="spectrum-Code5">${pubMoment.format('MMM Do')} ${(moment().year() !== pubMoment.year() ? moment.year() : '')} · <strong>${item.creator}</strong></code>
+        <h4 class="spectrum-Heading4">${item.title}</h4>
+        <p class="spectrum-Body4">${caption}</p>
+        <a href="${item.link}" class="spectrum-Button spectrum-Button--primary" style="margin: 20px 0;">Read On</a>
+        <hr class="spectrum-Rule spectrum-Rule--medium">`;
+        DOMUtil.spectrumify(div.querySelector('p.spectrum-Body4'));
         node.appendChild(div);
       });
     }

--- a/src/default_html.pre.js
+++ b/src/default_html.pre.js
@@ -90,11 +90,13 @@ async function pre(payload, action) {
 
     if (node.className.includes('index2')) {
       node.classList.add('spectrum--dark');
+      node.innerHTML = node.innerHTML.replace(/<h3/g, '<div class="guide-indent"><h3').replace(/<\/ul>/g, '</div></ul>');
       // DOMUtil.addClass(node, 'div:nth-of-type(1)', 'spectrum--dark');
       // grab last link and style it like a button
       DOMUtil.addClass(node, 'ul', 'removeStyle');
 
       const links = node.querySelectorAll('a');
+      // Alternating button colors
       links.forEach((link, i) => {
         if (i === 0 || i === 2) {
           link.classList.add('spectrum-Button', 'spectrum-Button--cta', 'button-read');
@@ -115,6 +117,8 @@ async function pre(payload, action) {
       // this is the medium blog feed
       feed.items.slice(0, 3).forEach((item) => {
         const pubMoment = moment(item.pubDate);
+        console.log(item.pubDate);
+        const contentVDOM = new VDOM(item['content:encoded'], secrets);
         const ps = item['content:encoded'].split('<p>');
         const firstStart = ps[1];
         const firstParagraphContent = firstStart.split('</p>')[0];
@@ -150,3 +154,8 @@ async function pre(payload, action) {
 }
 
 module.exports.pre = pre;
+
+function getAllText(node) {
+  node.childNodes.forEach(function(child) {
+  });
+}

--- a/src/html.htl
+++ b/src/html.htl
@@ -39,13 +39,13 @@ spectrum-css-diff.css file as well -->
     <nav class="navbar">
         <div class="navbar-logos">
             <span class="navbar-toggle" id="js-navbar-toggle">
-                <svg class="spectrum-Icon spectrum-Icon--sizeS" focusable="false" aria-hidden="true" aria-label="ShowMenu">
+                <svg class="spectrum-Icon spectrum-Icon--sizeM" focusable="false" aria-hidden="true" aria-label="ShowMenu">
                     <use xlink:href="#spectrum-icon-18-ShowMenu"></use>
                 </svg>
             </span>
             <a class="logo" href="/">
                 <svg class="logo-image" xmlns="http://www.w3.org/2000/svg"
-                    width="20" height="17" viewBox="0 0 24 20"
+                    width="24" height="20" viewBox="0 0 24 20"
                     focusable="false"
                 >
                     <path fill="#FF0000"
@@ -70,7 +70,7 @@ spectrum-css-diff.css file as well -->
             </li>
         </ul>
     </nav>
-    <div class="spectrum-grid--fluid">
+    <div class="spectrum-grid--fluid" style="padding: 0 8px;">
         <esi:include src="${payload.dispatch.url}" />
     </div>
     <nav id="footer" class="spectrum--darkest">


### PR DESCRIPTION
Re: adobe/developer.adobe.com-planning#126

Work in progress! Feel free to creep / review / leave comments.

# TODO

## Mobile View

- [ ] no real idea on how to handle the background images yet
- [x] the hamburger button needs to be positioned properly
- [x] there is a white margin / border around the whole page that needs to go - seems related to the `spectrum-grid--fluid` and `spectrum-grid-row` classes. `fluid` wants 16px padding on each side, whereas `row` sets a negative -8px margin on each side, so there's an 8px gap.
- [x] how to do the white bar indents in the authentication guides?
- [ ] how will we do the product spotlight carousel?
- [x] the recent blog articles contain a 'length of read'. this is not provided by the medium api. however, we are given the full text content of the article. could we estimate the read length based on that?
- [x] would be good to fix the current TODO in the blog article code around making sure we don't cut off unclosed tags
- [ ] the github projects need to be finalized (blocked on adobe/developer.adobe.com-planning#87)
- [x] add developer newsletter section

## Desktop View

Haven't even gotten there yet!