### PR TITLE
Homepage with content managed proposal

### DIFF
--- a/index.md
+++ b/index.md
@@ -4,11 +4,15 @@
 
 Customize and extend Adobe’s products to create better customer experiences with our APIs, help guides and community support.
 
+Search our products and documentation
+
 ---
 
 ![XD Logo](https://www.adobe.io/content/dam/udp/language-masters/en/xd_logo_43733775.svg)
+
 `The future of extending creative cloud apps`
-# Start Building with Adobe XD today
+
+## Start Building with Adobe XD today
 
 Create XD plugins to push the boundaries of experience design by adding new features to [Adobe XD](https://adobexdplatform.com/), automating workflows, connecting XD to external services, and more—all on a quick, modern JavaScript engine with native UI components.
 
@@ -46,3 +50,10 @@ The Adobe Analytics APIs are a collection of APIs that power Adobe Analytics pro
 
 ## Recent Blog Articles
 
+---
+
+## **Sign up** for our developer newsletter
+
+Enter your email address
+
+Subscribe

--- a/src/default_html.htl
+++ b/src/default_html.htl
@@ -1,11 +1,11 @@
 <div class="container spectrum-grid-row">
-  <div class="section index0 odd has-paragraph has-heading has-inlineCode nb-paragraph-1 nb-heading-1 nb-inlineCode-1 is-paragraph-heading-inlineCode is-paragraph-heading is-paragraph spectrum-grid-col-sm-12 spectrum-grid-col-md-6 spectrum--dark">
-    <p class="spectrum-Body3"><code class="spectrum-Code3">Find what you're looking for</code></p>
-    <h2 class="spectrum-Heading2">Do More with Adobe</h2>
-    <p class="spectrum-Body3">Customize and extend Adobe’s products to create better customer experiences with our APIs, help guides and community support.</p>
+  <div class="section index0 odd spectrum-grid-col-sm-12 spectrum-grid-col-md-6 spectrum--dark" data-sly-test="${content.heading}">
+    <p class="spectrum-Body3"><code class="spectrum-Code3">${content.heading.code}</code></p>
+    <h2 class="spectrum-Heading2">${content.heading.title}</h2>
+    <p class="spectrum-Body3">${content.heading.description}</p>
     <div class="search-control">
       <div class="spectrum-DecoratedTextfield is-decorated">
-        <label for="search-input" class="spectrum-FieldLabel">Search our products and documentation</label>
+        <label for="search-input" class="spectrum-FieldLabel">${content.heading.label}</label>
         <svg class="spectrum-Icon spectrum-UIIcon-Magnifier spectrum-Icon--sizeS spectrum-DecoratedTextfield-icon" focusable="false" aria-hidden="true" style="color: rgb(75, 75, 75);transform: rotate(90deg);margin-left:10px;">
           <use xlink:href="#spectrum-css-icon-Magnifier"></use>
         </svg>
@@ -13,47 +13,52 @@
       </div>
     </div>
   </div>
-  <div class="section index1 even has-link has-paragraph has-heading has-image has-inlineCode nb-link-2 nb-paragraph-1 nb-heading-1 nb-image-1 nb-inlineCode-1 is-link-paragraph-heading is-link-paragraph is-link spectrum-grid-col-sm-12 spectrum-grid-col-md-6">
+
+  <div class="section index1 even spectrum-grid-col-sm-12 spectrum-grid-col-md-6" data-sly-test="${content.featured}">
     <p class="spectrum-Body3">
-      <img src="https://www.adobe.io/content/dam/udp/language-masters/en/xd_logo_43733775.svg" alt="XD Logo">
-      <code class="spectrum-Code3">The future of extending creative cloud apps</code>
+      ${content.featured.img}
+      <code class="spectrum-Code3">${content.featured.code}</code>
     </p>
-    <h1 class="spectrum-Heading1">Start Building with Adobe XD today</h1>
-    <p class="spectrum-Body3">Create XD plugins to push the boundaries of experience design by adding new features to <a href="https://adobexdplatform.com/" class="spectrum-Link">Adobe XD</a>, automating workflows, connecting XD to external services, and more—all on a quick, modern JavaScript engine with native UI components.</p>
-    <p class="spectrum-Body3">Let’s supercharge the future of design together with XD plugins.</p>
-    <p class="spectrum-Body3"><a href="/xd/docs" class="spectrum-Link spectrum-Button spectrum-Button--primary">See What’s Possible</a></p>
+    <h1 class="spectrum-Heading1">${content.featured.title}</h1>
+    <p class="spectrum-Body3">${content.featured.content1}</p>
+    <p class="spectrum-Body3">${content.featured.content2}</p>
+    <p class="spectrum-Body3"><a href="${content.featured.link.href}" class="spectrum-Link spectrum-Button spectrum-Button--primary">${content.featured.link.label}</a></p>
   </div>
-  <div class="section index2 odd has-list has-paragraph has-heading nb-list-2 nb-paragraph-2 nb-heading-3 is-heading-list-paragraph is-heading-list is-heading spectrum-grid-col-sm-12 spectrum-grid-col-md-6 spectrum--dark">
-    <h2 class="spectrum-Heading2">Authentication Guides</h2>
+
+  <div class="section index2 odd spectrum-grid-col-sm-12 spectrum-grid-col-md-6 spectrum--dark" data-sly-test="${content.auth}">
+    <h2 class="spectrum-Heading2">${content.auth.title}</h2>
     <div class="guide-indent">
-      <h3 class="spectrum-Heading3">OAuth 2.0</h3>
-      <p class="spectrum-Body3">Adobe Cloud Platform APIs use the OAuth 2.0 protocol for authentication and authorization.</p>
+      <h3 class="spectrum-Heading3">${content.auth.part1.title}</h3>
+      <p class="spectrum-Body3">${content.auth.part1.description}</p>
       <ul class="removeStyle">
-        <li class="spectrum-Body3 li-no-margin-bottom"><a href="https://adobeioruntime.net/api/v1/web/io-solutions/adobe-oauth-playground/oauth.html" class="spectrum-Link spectrum-Button spectrum-Button--cta button-read">Read our Guide</a></li>
-        <li class="spectrum-Body3 li-no-margin-bottom"><a href="" class="spectrum-Link spectrum-Button spectrum-Button--primary">Generate Tokens</a></li>
+        <li class="spectrum-Body3 li-no-margin-bottom"><a href="${content.auth.part1.link1.href}" class="spectrum-Link spectrum-Button spectrum-Button--cta button-read">${content.auth.part1.link1.label}</a></li>
+        <li class="spectrum-Body3 li-no-margin-bottom"><a href="${content.auth.part1.link2.href}" class="spectrum-Link spectrum-Button spectrum-Button--primary">${content.auth.part1.link2.label}</a></li>
       </ul>
     </div>
     <div class="guide-indent">
-      <h3 class="spectrum-Heading3">JWT Quickstart</h3>
-      <p class="spectrum-Body3">API services tied to entitled Adobe products require a JSON Web Token (JWT) to retrieve access tokens for usage against authenticated endpoints</p>
+      <h3 class="spectrum-Heading3">${content.auth.part2.title}</h3>
+      <p class="spectrum-Body3">${content.auth.part2.description}</p>
       <ul class="removeStyle">
-        <li class="spectrum-Body3 li-no-margin-bottom"><a href="https://www.adobe.io/authentication/auth-methods.html#!adobeio/adobeio-documentation/master/auth/JWTAuthenticationQuickStart.md" class="spectrum-Link spectrum-Button spectrum-Button--cta button-read">Read our Guide</a></li>
+        <li class="spectrum-Body3 li-no-margin-bottom"><a href="${content.auth.part2.link1.href}" class="spectrum-Link spectrum-Button spectrum-Button--cta button-read">${content.auth.part2.link1.label}</a></li>
+        <li class="spectrum-Body3 li-no-margin-bottom" data-sly-test="${content.auth.part2.link2.label}"><a href="${content.auth.part2.link2.href}" class="spectrum-Link spectrum-Button spectrum-Button--primary">${content.auth.part2.link2.label}</a></li>
       </ul>
     </div>
   </div>
-  <div class="section index3 even has-link has-paragraph has-heading has-image has-inlineCode nb-link-1 nb-paragraph-1 nb-heading-1 nb-image-1 nb-inlineCode-1 is-link-paragraph-heading is-link-paragraph is-link spectrum-grid-col-sm-12 spectrum-grid-col-md-6">
+
+  <div class="section index3 even spectrum-grid-col-sm-12 spectrum-grid-col-md-6" data-sly-test="${content.spotlight}">
     <p class="spectrum-Body3">
-      <img src="https://www.adobe.com/content/dam/www/icons/analytics-cloud.svg" alt="Adobe Analytics Logo">
-      <code class="spectrum-Code3">Product Spotlight</code>
+      ${content.spotlight.img}
+      <code class="spectrum-Code3">${content.spotlight.code}</code>
     </p>
-    <h2 class="spectrum-Heading2">Adobe Analytics APIs</h2>
-    <p class="spectrum-Body3">The Adobe Analytics APIs are a collection of APIs that power Adobe Analytics products like Analysis Workspace. The APIs allow for the creation of data rich user interfaces that you can use to manipulate and integrate data. You can also create reports to explore, get insights, or answer important questions about your data.</p>
-    <p class="spectrum-Body3"><a href="" class="spectrum-Link spectrum-Button spectrum-Button--cta">Read the Docs</a></p>
+    <h2 class="spectrum-Heading2">${content.spotlight.title}</h2>
+    <p class="spectrum-Body3">${content.spotlight.description}</p>
+    <p class="spectrum-Body3"><a href="${content.spotlight.link.href}" class="spectrum-Link spectrum-Button spectrum-Button--cta">${content.spotlight.link.label}</a></p>
   </div>
-  <div id="techblog" class="section index4 odd has-heading nb-heading-1 is-heading-only spectrum-grid-col-sm-12 spectrum-grid-col-md-6" data-sly-test="${content.mediumArticles}">
-    <h2 class="spectrum-Heading2">Recent Blog Articles</h2>
+
+  <div id="techblog" class="section index4 odd spectrum-grid-col-sm-12 spectrum-grid-col-md-6" data-sly-test="${content.medium}">
+    <h2 class="spectrum-Heading2">${content.medium.meta.title}</h2>
     <hr class="spectrum-Rule spectrum-Rule--medium">
-    <div id="techblog-article-container" data-sly-list="${content.mediumArticles}">
+    <div id="techblog-article-container" data-sly-list="${content.medium.articles}">
       <div>
         <code class="spectrum-Code5">${item.pubDate} · ${item.minuteLength} min read · <strong>${item.creator}</strong></code>
         <h4 class="spectrum-Heading4">${item.title}</h4>
@@ -63,13 +68,14 @@
       </div>
     </div>
   </div>
-  <div class="section index5 even spectrum-grid-col-sm-12 spectrum-grid-col-md-6 spectrum--darkest">
-    <h2 class="spectrum-Heading2--quiet"><strong>Sign up</strong> for our developer newsletter</h2>
+  
+  <div class="section index5 even spectrum-grid-col-sm-12 spectrum-grid-col-md-6 spectrum--darkest" data-sly-test="${content.signup}">
+    <h2 class="spectrum-Heading2--quiet">${content.signup.title}</h2>
     <div class="newsletter-control">
       <div class="spectrum-DecoratedTextfield">
-        <label for="email-input" class="spectrum-FieldLabel">Enter your email address</label>
+        <label for="email-input" class="spectrum-FieldLabel">${content.signup.label}</label>
         <button id="newsletter-submit" class="spectrum-Button spectrum-Button--primary spectrum-DecoratedTextfield-icon">
-          <span class="spectrum-Button-label">Subscribe →</span>
+          <span class="spectrum-Button-label">${content.signup.action} →</span>
         </button>
         <input id="email-input" class="spectrum-Textfield" aria-invalid="false" type="text" style="background-color: rgb(255, 255, 255);border-color: rgb(225, 225, 225);color: rgb(75, 75, 75); border-radius: 30px;">
       </div>

--- a/src/default_html.pre.js
+++ b/src/default_html.pre.js
@@ -14,6 +14,7 @@
 const VDOM = require('@adobe/helix-pipeline').utils.vdom;
 const RSSParser = require('rss-parser');
 const moment = require('moment');
+const visit = require('unist-util-visit');
 const DOMUtil = require('./DOM_munging.js');
 
 const rss = new RSSParser();
@@ -34,6 +35,48 @@ function getAllWords(node) {
   return allText.filter(word => word.length && word.match(/^\w+\W?$/i));
 }
 
+function getSection(sections, index) {
+  if (sections && sections.length > index) {
+    return sections[index];
+  }
+  return null;
+}
+
+function getElement(action, section, tag, index = 0) {
+  const node = new VDOM(section, action.secrets).getNode();
+  const elements = node.querySelectorAll(tag);
+  const i = index === 'last' ? elements.length - 1 : index;
+  if (elements.length > i) {
+    return elements[i].innerHTML;
+  }
+  return '';
+}
+
+function getLink(action, section, index = 0) {
+  let href = '';
+  let label = '';
+  const node = new VDOM(section, action.secrets).getNode();
+  const elements = node.getElementsByTagName('a');
+  const i = index === 'last' ? elements.length - 1 : index;
+  if (elements.length > i) {
+    ({ href } = elements[i]);
+    label = elements[i].innerHTML;
+  }
+
+  return { label, href };
+}
+
+function getImage(action, section, index = 0) {
+  const node = new VDOM(section, action.secrets).getNode();
+  const elements = node.getElementsByTagName('img');
+  const i = index === 'last' ? elements.length - 1 : index;
+  if (elements.length > i) {
+    return elements[i].outerHTML;
+  }
+
+  return '';
+}
+
 // module.exports.pre is a function (taking next as an argument)
 // that returns a function (with payload, config, logger as arguments)
 // that calls next (after modifying the payload a bit)
@@ -50,43 +93,132 @@ async function pre(payload, action) {
     logger.warn('error durring parsing adobetech blog rss feed!', e);
   }
   const { content } = payload;
-  content.mediumArticles = false;
+
+  // allow fine-grain search on the DOM
+  content.sections.forEach((section) => {
+    visit(section, (child) => {
+      if (child && child.data && child.data.types) {
+        // assign the child types to the child className so that they get rendered
+        // eslint-disable-next-line no-param-reassign
+        child.data = Object.assign({
+          hProperties: {
+            className: child.data.types,
+          },
+        }, child.data || {});
+      }
+    });
+  });
+
+  const heading = getSection(content.sections, 0);
+  if (heading) {
+    content.heading = {
+      title: getElement(action, heading, 'h2'),
+      code: getElement(action, heading, 'code'),
+      description: getElement(action, heading, 'p.is-paragraph'),
+      label: getElement(action, heading, 'p.is-paragraph', 1),
+    };
+  }
+
+  const featured = getSection(content.sections, 1);
+  if (featured) {
+    content.featured = {
+      title: getElement(action, featured, 'h2'),
+      code: getElement(action, featured, 'code'),
+      content1: getElement(action, featured, 'p.is-paragraph'),
+      content2: getElement(action, featured, 'p.is-paragraph', 1),
+      img: getImage(action, featured),
+      link: getLink(action, featured, 'last'),
+    };
+  }
+
+  const auth = getSection(content.sections, 2);
+  if (auth) {
+    content.auth = {
+      title: getElement(action, auth, 'h2'),
+      part1: {
+        title: getElement(action, auth, 'h2', 1),
+        description: getElement(action, auth, 'p.is-paragraph'),
+        link1: getLink(action, auth),
+        link2: getLink(action, auth, 1),
+      },
+      part2: {
+        title: getElement(action, auth, 'h2', 2),
+        description: getElement(action, auth, 'p.is-paragraph', 1),
+        link1: getLink(action, auth, 2),
+        link2: getLink(action, auth, 3),
+      },
+    };
+  }
+
+  const spotlight = getSection(content.sections, 3);
+  if (spotlight) {
+    content.spotlight = {
+      title: getElement(action, spotlight, 'h2'),
+      code: getElement(action, spotlight, 'code'),
+      description: getElement(action, spotlight, 'p.is-paragraph'),
+      img: getImage(action, spotlight),
+      link: getLink(action, spotlight),
+    };
+  }
+
+  content.medium = false;
 
   // pull recent blog posts from medium
   if (feed) {
     const transformer = new VDOM(payload.content.sections[0], secrets);
     const document = transformer.getDocument();
-    content.mediumArticles = feed.items.slice(0, 3).map((item) => {
-      const pubMoment = moment(item.pubDate);
-      const temp = document.createElement('p');
-      temp.innerHTML = item['content:encoded'];
-      const articleWords = getAllWords(temp);
-      // brief googling yields a rough math of 265 words per minute read time
-      const minuteLength = Math.ceil(articleWords.length / 265);
-      const ps = item['content:encoded'].split('<p>');
-      const firstStart = ps[1];
-      const firstParagraphContent = firstStart.split('</p>')[0];
-      const secondParagraphContent = (ps[2] ? ps[2].split('</p>')[0] : '');
-      let caption = `${firstParagraphContent} ${secondParagraphContent}`;
-      if (caption.length > 340) {
-        // chop up caption into a tl;dr
-        caption = caption.substring(0, 340);
-        caption = caption.replace(/\w+$/, '...');
-      }
-      // let the virtual dom handle chopping up elements appropriately,
-      // otherwise we risk severing content mid-html-tag
-      temp.innerHTML = caption;
-      DOMUtil.spectrumify(temp);
-      caption = temp.innerHTML;
-      return {
-        pubDate: `${pubMoment.format('MMM Do')} ${(moment().year() !== pubMoment.year() ? moment.year() : '')}`,
-        creator: item.creator,
-        title: item.title,
-        caption,
-        minuteLength,
-        link: item.link,
-      };
-    });
+    const meta = {
+      title: 'Some Default Title',
+    };
+
+    const medium = getSection(content.sections, 4);
+    if (medium) {
+      meta.title = medium.title;
+    }
+
+    content.medium = {
+      articles: feed.items.slice(0, 3).map((item) => {
+        const pubMoment = moment(item.pubDate);
+        const temp = document.createElement('p');
+        temp.innerHTML = item['content:encoded'];
+        const articleWords = getAllWords(temp);
+        // brief googling yields a rough math of 265 words per minute read time
+        const minuteLength = Math.ceil(articleWords.length / 265);
+        const ps = item['content:encoded'].split('<p>');
+        const firstStart = ps[1];
+        const firstParagraphContent = firstStart.split('</p>')[0];
+        const secondParagraphContent = (ps[2] ? ps[2].split('</p>')[0] : '');
+        let caption = `${firstParagraphContent} ${secondParagraphContent}`;
+        if (caption.length > 340) {
+          // chop up caption into a tl;dr
+          caption = caption.substring(0, 340);
+          caption = caption.replace(/\w+$/, '...');
+        }
+        // let the virtual dom handle chopping up elements appropriately,
+        // otherwise we risk severing content mid-html-tag
+        temp.innerHTML = caption;
+        DOMUtil.spectrumify(temp);
+        caption = temp.innerHTML;
+        return {
+          pubDate: `${pubMoment.format('MMM Do')} ${(moment().year() !== pubMoment.year() ? moment.year() : '')}`,
+          creator: item.creator,
+          title: item.title,
+          caption,
+          minuteLength,
+          link: item.link,
+        };
+      }),
+      meta,
+    };
+  }
+
+  const signup = getSection(content.sections, 5);
+  if (signup) {
+    content.signup = {
+      title: getElement(action, signup, 'h2'),
+      label: getElement(action, signup, 'p'),
+      action: getElement(action, signup, 'p', 1),
+    };
   }
 
   return payload;


### PR DESCRIPTION
@filmaj Here is a proposal based on your "homepage" branch - I extracted the "content" from the HTL and use the content still coming from the markup. That's a half-way solution. The pre.js is simply computing the data to be injected in the HTL - much easier for a web dev to build the page and still you keep the content authoring part.

This one big constraint to this approach: the content must have the required structure, otherwise, things might break. I will continue investigating on how to improve this.

Note: the XD section is not fully complete, I found a bug in Helix. Will fix it asap.

WDYT ?