### PR TITLE
Adding strains for central support page

### DIFF
--- a/helix-config.yaml
+++ b/helix-config.yaml
@@ -75,3 +75,6 @@ strains:
   - name: production
     <<: *proxystrain
     url: https://developer.adobe.com/
+  - name: support
+    origin: https://adobedocs.github.io/developer-support/
+    url: https://developer.adobe.com/support


### PR DESCRIPTION
developer.adobe.com/support should serve the github page at https://adobedocs.github.io/developer-support/. Added the config to enable the strain.