### PR TITLE
Adding strain for central support page-staging

### DIFF
--- a/helix-config.yaml
+++ b/helix-config.yaml
@@ -52,6 +52,10 @@ strains:
   - name: staging
     <<: *proxystrain
     url: https://adobedevsite.helix-demo.xyz/
+  - name: support-staging
+    origin: https://adobedocs.github.io/developer-support/
+    url: https://adobedevsite.helix-demo.xyz/support
+  
 
   # === PRODUCTION URLS FOLLOW ===
   - name: launch-docs-production


### PR DESCRIPTION
https://adobedevsite.helix-demo.xyz/support should serve central support page at  https://adobedocs.github.io/developer-support/