### PR TITLE
fix(package): The repository has moved URL

### DIFF
--- a/helix-config.yaml
+++ b/helix-config.yaml
@@ -40,7 +40,7 @@ strains:
     <<: *devDefaults
     url: https://adobedevsite.helix-demo.xyz/launch/docs
     # TODO: the following repo has no author or staging branch
-    content: https://github.com/Adobe-Marketing-Cloud/reactor-user-docs.git#master
+    content: https://github.com/adobe/reactor-user-docs.git#master
     directoryIndex: README.html
     package: developer-adobe-com/ce5db49d1525a068bee7fb68cfa87808abbba4f0
   - name: xd-docs-dev
@@ -75,7 +75,7 @@ strains:
   - name: launch-docs-production
     <<: *productionDefaults
     url: https://developer.adobe.com/launch/docs
-    content: https://github.com/Adobe-Marketing-Cloud/reactor-user-docs.git#master
+    content: https://github.com/adobe/reactor-user-docs.git#master
     directoryIndex: README.html
     package: developer-adobe-com/ce5db49d1525a068bee7fb68cfa87808abbba4f0
   - name: xd-docs-production


### PR DESCRIPTION
<!-- Copyright 2019 Adobe. All rights reserved.
This file is licensed to you under the Apache License, Version 2.0 (the "License");
you may not use this file except in compliance with the License. You may obtain a copy
of the License at http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software distributed under
the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
OF ANY KIND, either express or implied. See the License for the specific language
governing permissions and limitations under the License. -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
The package.json file is currently pointed to `Adobe-Marketing-Cloud`, the repository now currently lives at `adobe`.
<!--- Describe your changes in detail -->
## Types of changes

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [✓] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [✓] I have read the **CONTRIBUTING** document.